### PR TITLE
Repaint after each touch

### DIFF
--- a/calibrate-touchscreen/src/main.rs
+++ b/calibrate-touchscreen/src/main.rs
@@ -76,6 +76,7 @@ impl FullscreenSurface {
         );
 
         self.wl_surface.attach(Some(&buffer), 0, 0);
+        self.wl_surface.damage(0, 0, width, height);
         self.wl_surface.commit();
         buffer.destroy();
     }


### PR DESCRIPTION
This merge request fixes an issue with the touchscreen calibration where the screen does not update after the first target is touched. The problem was due to the compositor not being informed that the surface's contents had changed after the initial draw.


Solves https://github.com/AlanGriffiths/libinput/issues/7